### PR TITLE
fix compile issues

### DIFF
--- a/test/makefile
+++ b/test/makefile
@@ -2,7 +2,7 @@ CXX=g++
 CFLAGS=-g -O2 -Wall -fPIC -Wno-deprecated
 
 INC=-I../include
-LIB=-L../lib -lereactor /usr/local/lib/libprotobuf.a -lrt
+LIB=-L../lib -lereactor /usr/local/lib/libprotobuf.a -lrt -lpthread
 OBJS = $(addsuffix .o, $(basename $(wildcard *.cc)))
 
 all:


### PR DESCRIPTION
When using -std=c++14, there will be an error to compile such files, indicating that the missing of linking to thread library.